### PR TITLE
Remove unnecessary things in the copied string

### DIFF
--- a/src/main/java/com/couturey/f3c/mixin/F3CMixin.java
+++ b/src/main/java/com/couturey/f3c/mixin/F3CMixin.java
@@ -25,7 +25,7 @@ public class F3CMixin {
 				int y = (int) Math.round(MinecraftClient.getInstance().player.getY());
 				int z = (int) Math.round(MinecraftClient.getInstance().player.getZ());
 
-				String coordinates = String.format("x: %d, y: %d, z: %d", x, y, z);
+				String coordinates = String.format("%d %d %d", x, y, z);
 				GLFW.glfwSetClipboardString(MinecraftClient.getInstance().getWindow().getHandle(), coordinates);
 
 				keysPressed = true;


### PR DESCRIPTION
X, Y, and Z is specifically mentioned in the copied string. This is useless, and most players know which value is for which.
This only makes things annoying, such as for pasting the coordinates into `/tp`, or in a worldedit command for example